### PR TITLE
Update links.json

### DIFF
--- a/links.json
+++ b/links.json
@@ -479,7 +479,7 @@
     "name": "寒夏Rainiar",
     "url": "https://blog.rainiar.top"
   },
-  {
+{
     "avatar": "https://github.com/LineXic.png",
     "blog": "LineXic书屋",
     "color": "#fb3936",
@@ -489,10 +489,10 @@
   },
   {
     "avatar": "https://img.dao.js.cn/zb_users/upload/2021/10/202110151634246697912592.png-webp",
-    "blog": "南蛮子懋和",
-    "color": "#fb3936",
+    "blog": "懋和道人",
+    "color": "#D14836",
     "desc": "李懋和，俗名李栋梁。书法、国画爱好者，互联网安全与前端建设者。",
     "name": "南蛮子懋和",
     "url": "https://www.dao.js.cn"
-  }
+  }  
 ]


### PR DESCRIPTION
名称：南蛮子懋和
地址：https://www.dao.js.cn/
头像：https://img.dao.js.cn/zb_users/upload/2021/10/202110151634246697912592.png-webp feed：https://www.dao.js.cn/feed.php
描述：李懋和，俗名李栋梁。书法、国画爱好者，互联网安全与前端建设者。

